### PR TITLE
Fix Taskwarrior update timestamp formatting

### DIFF
--- a/task_hooks/on-modify-update.py
+++ b/task_hooks/on-modify-update.py
@@ -16,8 +16,15 @@ def main():
                 print(json.dumps(mtask))
             else:
                 old_content = otask['update'] + '\n'
-                mtask['update'] = old_content + \
-                    time.strftime("%y:%M:%d %H:%m:%S: ") + mtask['update']
+                # Prepend a timestamp to the new update entry. The previous
+                # implementation incorrectly swapped the month and minute
+                # fields, producing output such as `25:48:26` for July 26th at
+                # 00:48. Use the correct format of `YY:MM:DD HH:MM:SS:`.
+                mtask['update'] = (
+                    old_content
+                    + time.strftime("%y:%m:%d %H:%M:%S: ")
+                    + mtask['update']
+                )
                 print(json.dumps(mtask))
     else:
         print(json.dumps(mtask))


### PR DESCRIPTION
## Summary
- fix incorrect month/minute formatting in `on-modify-update.py`

## Testing
- `python3 -m py_compile task_hooks/on-modify-update.py`
- `python3 task_hooks/on-modify-update.py < /tmp/testhook.txt`

------
https://chatgpt.com/codex/tasks/task_e_6884253ba438832687765871bd6d34f3