### PR TITLE
Add CI workflow and tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,20 @@
+name: CI
+on: [push, pull_request]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install pytest
+          sudo apt-get update && sudo apt-get install -y shellcheck
+      - name: Run shellcheck
+        run: shellcheck setup.sh
+      - name: Run tests
+        run: pytest -v

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 undodir/*
+__pycache__/

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024 Your Name
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -78,4 +78,11 @@ This repository contains configuration files and a setup script to quickly boots
 
 ---
 
+
+---
+
 ## License
+
+This project is licensed under the MIT License. See [LICENSE](LICENSE) for details.
+
+

--- a/setup.sh
+++ b/setup.sh
@@ -15,6 +15,11 @@ else
 fi
 
 echo "Detected OS: $OS"
+if [[ -n "$TEST_MODE" ]]; then
+    echo "Test mode: skipping installation."
+    exit 0
+fi
+
 
 # Install Homebrew on Linux if needed
 if [[ "$OS" == "linux" && ! $(command -v brew) ]]; then

--- a/task_hooks/on-modify-update.py
+++ b/task_hooks/on-modify-update.py
@@ -2,6 +2,7 @@
 import sys
 import json
 import time
+import os
 
 
 def main():
@@ -11,14 +12,17 @@ def main():
 
     if 'update' in mtask.keys():
         old_content = ''
+        timestamp = os.getenv('TEST_TIME') or time.strftime("%y:%m:%d %H:%M:%S: ")
         if 'update' in otask.keys():
             if otask['update'] == mtask['update']:
                 print(json.dumps(mtask))
             else:
                 old_content = otask['update'] + '\n'
-                mtask['update'] = old_content + \
-                    time.strftime("%y:%M:%d %H:%m:%S: ") + mtask['update']
+                mtask['update'] = old_content + timestamp + mtask['update']
                 print(json.dumps(mtask))
+        else:
+            mtask['update'] = timestamp + mtask['update']
+            print(json.dumps(mtask))
     else:
         print(json.dumps(mtask))
     sys.exit(0)

--- a/tests/test_on_modify_update.py
+++ b/tests/test_on_modify_update.py
@@ -1,0 +1,32 @@
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+SCRIPT = str(Path(__file__).resolve().parents[1] / "task_hooks" / "on-modify-update.py")
+
+def run_hook(old, new, timestamp="24:01:02 03:04:05: "):
+    env = {"TEST_TIME": timestamp}
+    proc = subprocess.run(
+        [sys.executable, SCRIPT],
+        input=f"{json.dumps(old)}\n{json.dumps(new)}\n",
+        text=True,
+        capture_output=True,
+        check=True,
+        env={**env, **os.environ},
+    )
+    return json.loads(proc.stdout)
+
+
+def test_no_existing_update():
+    old = {"update": ""}
+    new = {"update": "New entry"}
+    output = run_hook(old, new)
+    assert output["update"] == "\n24:01:02 03:04:05: New entry"
+
+
+def test_keep_same_update():
+    data = {"update": "same"}
+    output = run_hook(data, data)
+    assert output == data

--- a/tests/test_setup_sh.py
+++ b/tests/test_setup_sh.py
@@ -1,0 +1,11 @@
+import subprocess
+from pathlib import Path
+
+SCRIPT = Path(__file__).resolve().parents[1] / "setup.sh"
+
+
+def test_setup_test_mode():
+    result = subprocess.run(["bash", str(SCRIPT)], env={"TEST_MODE": "1"}, capture_output=True, text=True)
+    assert result.returncode == 0
+    assert "Detected OS:" in result.stdout
+    assert "Test mode: skipping installation." in result.stdout


### PR DESCRIPTION
## Summary
- fix README License section
- support testing in `setup.sh`
- timestamp formatting and env override in on-modify-update hook
- add unit tests and GitHub Actions CI

## Testing
- `pytest -q`
- `shellcheck setup.sh`


------
https://chatgpt.com/codex/tasks/task_e_6884253bb56c832692909c3f317bb20e