### PR TITLE
Add luacheck configuration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,25 @@
+name: CI
+
+on:
+  push:
+    branches: [ main, master ]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y shellcheck luarocks lua5.1
+          sudo luarocks install luacheck
+      - name: ShellCheck
+        run: shellcheck $(git ls-files '*.sh')
+      - name: Python syntax
+        run: python3 -m py_compile $(git ls-files '*.py')
+      - name: Lua syntax
+        run: find nvim -name '*.lua' -print0 | xargs -0 luac -p
+      - name: Lua lint
+        run: luacheck nvim

--- a/.luacheckrc
+++ b/.luacheckrc
@@ -1,0 +1,5 @@
+std = "lua51"
+read_globals = { "vim" }
+new_globals = { "SetAutoCmp" }
+unused_args = false
+max_line_length = false

--- a/README.md
+++ b/README.md
@@ -76,6 +76,12 @@ This repository contains configuration files and a setup script to quickly boots
 - If you want to use a different package manager or OS, you may need to adapt the script.
 - After running, log out and log back in to activate zsh as your default shell if prompted.
 
+## Continuous Integration
+
+All shell, Python, and Lua scripts are automatically checked on every commit using
+[GitHub Actions](.github/workflows/ci.yml). Lua linting is configured via
+[`.luacheckrc`](.luacheckrc) to allow Neovim globals and ignore long lines.
+
 ---
 
 ## License


### PR DESCRIPTION
## Summary
- add `.luacheckrc` to suppress warnings for Neovim globals and long lines
- document lua linting config in README

## Testing
- `shellcheck $(git ls-files '*.sh') && python3 -m py_compile $(git ls-files '*.py') && find nvim -name '*.lua' -print0 | xargs -0 luac -p && luacheck nvim`


------
https://chatgpt.com/codex/tasks/task_e_6884354763788326950dcf5a1951f5a2